### PR TITLE
Fix max vcpus

### DIFF
--- a/build-job-queue.yaml
+++ b/build-job-queue.yaml
@@ -168,8 +168,8 @@ Resources:
       ComputeResources:
         Type: EC2
         MinvCpus: 0
-        DesiredvCpus: 128
-        MaxvCpus: 128
+        DesiredvCpus: 32
+        MaxvCpus: 32
         AllocationStrategy: BEST_FIT_PROGRESSIVE
         InstanceTypes:
         - optimal


### PR DESCRIPTION
It seems that new accounts only have a limit of 32 vCPUs and batch leaves EC2 instances running forever when you ask for more than this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
